### PR TITLE
HG-66 Modify payment processing to satisfy new domain requirements

### DIFF
--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -275,7 +275,7 @@ struct ShopState {
 }
 
 struct ShopParams {
-    1: required domain.CategoryObject category
+    1: required domain.CategoryRef category
     2: required domain.ShopDetails details
     3: optional domain.Contractor contractor
 }


### PR DESCRIPTION
Как мы видим, в структуре `domain.Shop` отныне используется `CategoryRef` вместо `Category`
