### PR TITLE
MST-34 Интеграция магисты с колубусом

### DIFF
--- a/proto/geo_ip.thrift
+++ b/proto/geo_ip.thrift
@@ -18,7 +18,7 @@ struct LocationInfo {
     2: required GeoID country_geo_id;
     // Полное описание локации в json
     // подробное описание на сайте https://www.maxmind.com/en/geoip2-city
-    3: required string raw_response;
+    3: optional string raw_response;
 }
 // Информация о регоине
 struct SubdivisionInfo{

--- a/proto/merch_stat.thrift
+++ b/proto/merch_stat.thrift
@@ -4,6 +4,7 @@
 
 include "base.thrift"
 include "domain.thrift"
+include "geo_ip.thrift"
 
 namespace java com.rbkmoney.damsel.merch_stat
 namespace erlang merchstat
@@ -14,14 +15,7 @@ namespace erlang merchstat
 struct StatPayment {
     1: required domain.InvoiceID invoice_id
     2: required domain.InvoicePayment payment
-    3: optional GeoInfo geo_info
-}
-
-/**
-* Гео-данные платежа. Соcтоит из имени города (определяется по IP).
-*/
-struct GeoInfo {
-    1: optional string city_name
+    3: optional geo_ip.LocationInfo location_info
 }
 
 /**


### PR DESCRIPTION
магиста теперь отдает айдишники гео объектов вместо их названия, название можно получить используя колумбус в зависимости от требуемого языка на фронте