### PR TITLE
wrapper for typedef

### DIFF
--- a/proto/papidmt.thrift
+++ b/proto/papidmt.thrift
@@ -1,0 +1,8 @@
+include "domain_config.thrift"
+
+namespace java com.rbkmoney.damsel.papidmt
+namespace erlang papidmt
+
+struct HistoryWrapper {
+    1: required domain_config.History history
+}


### PR DESCRIPTION
Обертка для типов введенных с помощью typedef, которые не отображаются нормально в java объект, о них вообще нет никакой информации, что не  позволяет проводить их сериализацию, десериализацию в java, так как таких методов в интрефейсе сериализатора не предусмотрено.

Пример:
в дамзель имеем:
typedef map<Version, Commit> History
в джаве мы ничего не знаем о типе History 
и если существует метод: History method(History history) , то в java мы имеем:
map<Version, Commit> method(map<Version, Commit>  history)


