### PR TITLE
MST-55:  fixed null pointer case for unknown geoid

### DIFF
--- a/proto/geo_ip.thrift
+++ b/proto/geo_ip.thrift
@@ -31,7 +31,7 @@ struct SubdivisionInfo{
 * Информация о данном GeoID
 **/
 struct GeoIDInfo{
-   2: optional string country_name;
+   2: required string country_name;
    3: optional set<SubdivisionInfo> subdivisions;
    4: optional string city_name;
 }
@@ -58,6 +58,7 @@ service GeoIpService {
     * lang - язык ответа. Например: "RU", "ENG"
     *
     * если по данному geo-id нужная детализация не обнаружена, соответствующее поле в возвращаемой структуре останется не заполненным
+    * если в результате по данному geo-id не обнаружено никаких данных, он не попадает в возвращаемый результат
     * если язык не поддерживается -> InvalidRequest
     **/
     map <GeoID, GeoIDInfo> GetLocationInfo (1: set<GeoID> geo_ids, 2: string lang) throws (1: base.InvalidRequest ex1)
@@ -68,7 +69,7 @@ service GeoIpService {
      * При передаче geoID региона - название региона
      * При передаче geoID города - название города
      * и т.д.
-     * Если передан неизвестный geoID, возвращается пустая строка
+     * Если передан неизвестный geoID, он не попадет в возвращаемый результат
      **/
      map <GeoID, string> GetLocationName (1: set<GeoID> geo_ids, 2: string lang) throws (1: base.InvalidRequest ex1)
 


### PR DESCRIPTION
Thrift can't handle nulls in collections, columbus iface changed to eliminate these cases