### PR TITLE
Invoice info in every invoice related events

### DIFF
--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -95,7 +95,7 @@ typedef list<Event> Events
  */
 union EventPayload {
     /** Некоторое событие, порождённое инвойсом. */
-    1: InvoiceEvent            invoice_event
+    1: InvoceEventWrapper            invoice_event_wrapper
     /** Некоторое событие, порождённое участником. */
     2: PartyEvent              party_event
 }
@@ -103,6 +103,11 @@ union EventPayload {
 /**
  * Один из возможных вариантов события, порождённого инвойсом.
  */
+struct InvoceEventWrapper {
+    1: required domain.Invoice invoice
+    2: required InvoiceEvent invoice_event
+}
+
 union InvoiceEvent {
     1: InvoiceCreated          invoice_created
     2: InvoiceStatusChanged    invoice_status_changed
@@ -124,8 +129,6 @@ union InvoicePaymentEvent {
  * Событие о создании нового инвойса.
  */
 struct InvoiceCreated {
-    /** Данные созданного инвойса. */
-    1: required domain.Invoice invoice
 }
 
 /**


### PR DESCRIPTION
if it is possible to do it will reduce a lot of stupid work on huge bunch of java services where we have to save invoice information on first event (InvoiceCreated) and construct it every time on a new invoice event by querying db