### PR TITLE
MST-104: Add error classes

### DIFF
--- a/proto/merch_stat.thrift
+++ b/proto/merch_stat.thrift
@@ -84,7 +84,6 @@ struct StatInvoice {
     9 : required domain.Amount amount
     10: required string currency_symbolic_code
     11: optional base.Content context
-    12: optional domain.InvoiceTemplateID template_id
 }
 
 struct InvoiceUnpaid    {}


### PR DESCRIPTION
Добавлены классы ошибок по аналогии с domain.thrift. Сначала предполагалось, что сюда я сразу добавлю и invoice_template_id, но не вышло.