### PR TITLE
PayoutType -> PayoutTool

### DIFF
--- a/proto/merch_stat.thrift
+++ b/proto/merch_stat.thrift
@@ -69,6 +69,13 @@ struct BankCard {
     4: required string masked_pan
 }
 
+struct BankAccount {
+    1: required string account
+    2: required string bank_name
+    3: required string bank_post_account
+    4: required string bank_bik
+}
+
 /**
 * Информация об инвойсе.
 */
@@ -120,7 +127,22 @@ struct StatPayout {
     6 : required domain.Amount amount
     7 : required domain.Amount fee
     8 : required string currency_symbolic_code
-    9 : required PayoutType payout_type
+    9 : required PayoutType type
+}
+
+union PayoutType {
+    1: PayoutCard card
+    2: PayoutAccount account
+}
+
+struct PayoutCard {
+    1: required BankCard card
+}
+
+struct PayoutAccount {
+    1: required BankAccount account
+    4: required string inn
+    5: required string purpose
 }
 
 union PayoutStatus {
@@ -134,25 +156,6 @@ struct PayoutUnpaid {}
 struct PayoutPaid {}
 struct PayoutCancelled { 1: required string details }
 struct PayoutConfirmed {}
-
-union PayoutType {
-    1: PayoutCard payout_card
-    2: PayoutAccount payout_account
-}
-
-struct PayoutCard {
-    1: required string mask_pan
-    2: required domain.BankCardPaymentSystem payment_system
-    3: required string bin
-}
-
-struct PayoutAccount {
-    1: required string account
-    2: required string bank_corr_account
-    3: required string bank_bik
-    4: required string inn
-    5: required string purpose
-}
 
 typedef map<string, string> StatInfo
 typedef base.InvalidRequest InvalidRequest

--- a/proto/payout_processing.thrift
+++ b/proto/payout_processing.thrift
@@ -98,7 +98,7 @@ struct Payout {
     4: required base.Timestamp created_at
     5: required PayoutStatus status
     6: required domain.FinalCashFlow payout_flow
-    7: required PayoutType payout_type
+    7: required PayoutType type
 }
 
 /**
@@ -165,30 +165,20 @@ struct PayoutConfirmed {
 
 /* Типы выплаты */
 union PayoutType {
-    1: PayoutCard payout_card
-    2: PayoutAccount payout_account
+    1: PayoutCard card
+    2: PayoutAccount account
 }
 
 /* Выплата на карту */
 struct PayoutCard {
-    /* Идентификатор запроса на выплату */
-    1: required string request_id
-    /* Данные по карте */
-    2: required domain.BankCard bank_card
+    1: required domain.BankCard card
 }
 
 /* Вывод на расчетный счет */
 struct PayoutAccount {
-    /* Расчетный счет */
-    1: required string account
-    /* Корреспондентский счет */
-    2: required string bank_corr_account
-    /* БИК */
-    3: required string bank_bik
-    /* ИНН организации */
-    4: required string inn
-    /* Назначение платежа */
-    5: required string purpose
+    1: required domain.BankAccount account
+    2: required string inn
+    3: required string purpose
 }
 
 /**


### PR DESCRIPTION
Мы все переиграли, и теперь PayoutType стал PayoutTool'ом. А еще:
- purpose теперь как поле самой выплаты
- inn и request_id теперь не нужны

~~PayoutTool разделен на два типа:~~
~~* Автоматические средства выплаты (средства выплаты создаются заранее)~~
~~* AdHoc выплаты (средства выплаты создаются в момент выплаты)~~

~~К автоматическим средствам выплаты можно отнести выплаты на счет и на карту.~~
~~AdHoc выплаты проходят только на карту.~~

~~Осталось понять, куда присунуть inn, хотя в том же bank_account например есть bank_bik,~~ ~~который прям очень русский.~~

