### PR TITLE
Make status reasons optional in claims

### DIFF
--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -852,11 +852,11 @@ struct ClaimAccepted {
 }
 
 struct ClaimDenied {
-    1: required string reason
+    1: optional string reason
 }
 
 struct ClaimRevoked {
-    1: required string reason
+    1: optional string reason
 }
 
 // Claim effects


### PR DESCRIPTION
They are _implicit_ in RPC declarations which means they may come in undefined.