### PR TITLE
CAPI-197: add forgotten UserInteraction event change

### DIFF
--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -864,8 +864,9 @@ struct CustomerBindingFailed    { 1: required domain.OperationFailure failure }
 
 // Events
 union CustomerBindingChangePayload {
-    1: CustomerBindingStarted        customer_binding_started
-    2: CustomerBindingStatusChanged  customer_binding_status_changed
+    1: CustomerBindingStarted started
+    2: CustomerBindingStatusChanged status_changed
+    3: CustomerBindingInteractionRequested interaction_requested
 }
 
 /**
@@ -880,6 +881,10 @@ struct CustomerBindingStarted {
  */
 struct CustomerBindingStatusChanged {
     1: required CustomerBindingStatus status
+}
+
+struct CustomerBindingInteractionRequested {
+    1: required user_interaction.UserInteraction interaction
 }
 
 // Exceptions


### PR DESCRIPTION
Я не понимаю схему работы с двумя евент-синками. (((
В swag есть евент у кастомера [CustomerBindingInteractionRequested](https://github.com/rbkmoney/swag/blob/epic/subscriptions-release/swagger.yaml#L2317), а в дамзеле ничего подобного у кастомера нет. Этот ивент есть тольку у рекурентных токенов. Как его предполагается получить? Капи должен полить только кастомера или еще дополнительно полить рекурентов?