### PR TITLE
PROX-136: removed optional token

### DIFF
--- a/proto/proxy_provider.thrift
+++ b/proto/proxy_provider.thrift
@@ -40,7 +40,6 @@ struct RecurrentTokenContext {
 struct RecurrentTokenProxyResult {
     1: required RecurrentTokenIntent   intent
     2: optional proxy.ProxyState       next_state
-    3: optional domain.Token           token
     4: optional domain.TransactionInfo trx
 }
 


### PR DESCRIPTION
[Damsel: 2 токена в структуре рекуррентов для адаптеров (проксиков)](https://rbkmoney.atlassian.net/browse/PROX-136)