### PR TITLE
HG-497: Customer binding desync

### DIFF
--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -1108,21 +1108,21 @@ struct CustomerBinding {
 
 // Statuses
 union CustomerBindingStatus {
+    4: CustomerBindingCreating  creating
     1: CustomerBindingPending   pending
-    4: CustomerBindingProcessed processed
     2: CustomerBindingSucceeded succeeded
     3: CustomerBindingFailed    failed
 }
 
 /**
+ * Привязка находится в процессе создания
+ */
+struct CustomerBindingCreating {}
+
+/**
  * Привязка находится в процессе обработки
  */
 struct CustomerBindingPending   {}
-
-/**
- * Привязка обработана (recurrent_paytool создан)
- */
-struct CustomerBindingProcessed {}
 
 /**
  * Привязка завершилась успешно


### PR DESCRIPTION
Добавил кастомный id в параметры создания RecurrentPaymentTool и новый статус в CustomerBinding.

Думаю сделать так - генерировать Id для пейтула в StartBinding, сохранять его в эвентах, а потом уже по таймауту создавать машину и переводить CustomerBinding в статус pending.