### PR TITLE
PROX-371: add mpi_preauthorization_failed

### DIFF
--- a/proto/claim_management.thrift
+++ b/proto/claim_management.thrift
@@ -242,6 +242,7 @@ union Modification {
 
 struct Claim {
     1: required ClaimID id
+    8: required domain.PartyID party_id
     2: required ClaimStatus status
     3: required ClaimChangeset changeset
     4: required ClaimRevision revision


### PR DESCRIPTION
В рамках задачи [PayCenter. Добавить TimeoutBehaviour](https://rbkmoney.atlassian.net/browse/PROX-371) необходимо создать ошибку, которая будет вместо timeout-а и говорить о том, что человек не вернулся с 3ds