### PR TITLE
FF-183: make fields in withdrawal provision terms optional

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2014,10 +2014,10 @@ struct RecurrentPaytoolsProvisionTerms {
 }
 
 struct WithdrawalProvisionTerms {
-    1: required CurrencySelector currencies
-    2: required PayoutMethodSelector payout_methods
-    3: required CashLimitSelector cash_limit
-    4: required CashFlowSelector cash_flow
+    1: optional CurrencySelector currencies
+    2: optional PayoutMethodSelector payout_methods
+    3: optional CashLimitSelector cash_limit
+    4: optional CashFlowSelector cash_flow
 }
 
 struct P2PProvisionTerms {


### PR DESCRIPTION
Привожу `WithdrawalProvisionTerms` в соотвествие с `PaymentsProvisionTerms` чтобы можно было утилизировать аналогичную пейментам логику при роутинге, когда отсутвие `WithdrawalProvisionTerms` для терминала означает запрет проведения операций, и можно было корректно мержить только нужные условия терминалов и провайдеров.