### PR TITLE
DС-127: Handle untokenized google pay cards (#568)

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1535,8 +1535,8 @@ union PaymentMethod {
 }
 
 struct BankCardPaymentMethod {
-    1: optional BankCardPaymentSystem payment_system
-    2: optional bool                  is_cvv_empty
+    1: required BankCardPaymentSystem payment_system
+    2: optional bool                  is_cvv_empty = false
     3: optional BankCardTokenProvider token_provider
     4: optional TokenizationMethod    tokenization_method
 }

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1480,13 +1480,22 @@ struct CashLimitDecision {
 /* Payment methods */
 
 union PaymentMethod {
-    1: BankCardPaymentSystem bank_card
     2: TerminalPaymentProvider payment_terminal
     3: DigitalWalletProvider digital_wallet
-    4: TokenizedBankCard tokenized_bank_card
-    5: BankCardPaymentSystem empty_cvv_bank_card
     6: CryptoCurrency crypto_currency
     7: MobileOperator mobile
+    8: BankCardPaymentMethod bank_card
+    // Deprecated, use BankCardPaymentMethod instead
+    1: BankCardPaymentSystem bank_card_deprecated
+    4: TokenizedBankCard tokenized_bank_card_deprecated
+    5: BankCardPaymentSystem empty_cvv_bank_card_deprecated
+}
+
+struct BankCardPaymentMethod {
+    1: required BankCardPaymentSystem payment_system
+    2: required bool                  has_cvv
+    3: optional BankCardTokenProvider token_provider
+    4: optional TokenizationMethod    tokenization_method
 }
 
 struct TokenizedBankCard {
@@ -1561,6 +1570,7 @@ struct BankCard {
     9: optional bool is_cvv_empty
    10: optional BankCardExpDate exp_date
    11: optional string cardholder_name
+   12: optional TokenizationMethod tokenization_method
 }
 
 /** Дата экспирации */

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1493,7 +1493,7 @@ union PaymentMethod {
 
 struct BankCardPaymentMethod {
     1: required BankCardPaymentSystem payment_system
-    2: required bool                  has_cvv
+    2: required bool                  is_cvv_empty
     3: optional BankCardTokenProvider token_provider
     4: optional TokenizationMethod    tokenization_method
 }

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1570,7 +1570,6 @@ struct BankCard {
     9: optional bool is_cvv_empty
    10: optional BankCardExpDate exp_date
    11: optional string cardholder_name
-   12: optional TokenizationMethod tokenization_method
 }
 
 /** Дата экспирации */

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1535,8 +1535,8 @@ union PaymentMethod {
 }
 
 struct BankCardPaymentMethod {
-    1: required BankCardPaymentSystem payment_system
-    2: required bool                  is_cvv_empty
+    1: optional BankCardPaymentSystem payment_system
+    2: optional bool                  is_cvv_empty
     3: optional BankCardTokenProvider token_provider
     4: optional TokenizationMethod    tokenization_method
 }


### PR DESCRIPTION
* Unify different bank card-related Payment methods

* Add studid-simple flag for non-tokenized cards

* Fix wrong order in typedef

* Rename boolean -> bool

* Reintroduce old PaymentMethods to ensure backwards compatibility

* Replace is_tokenized with card_provider

* Add BankCardProvider condition

* Add _deprecated suffix to old bank card-related payment methods

* Put deprecated payment methods in the end of definition

* Replace BankCardProvider with TokenizationMethod