### PR TITLE
DC-119: Create own rulesets for permission and prohobitions 

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2383,7 +2383,7 @@ struct ContractPaymentInstitutionDefaults {
 
 struct PaymentRouting {
     1: required PaymentRoutingRulesetRef policies
-    2: required PaymentRoutingRulesetRef prohobitions
+    2: required PaymentRoutingRulesetRef prohibitions
 }
 
 struct PaymentRoutingRulesetRef { 1: required ObjectID id }

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2363,7 +2363,7 @@ struct PaymentInstitution {
     13: optional WithdrawalProviderSelector withdrawal_providers
     14: optional P2PProviderSelector p2p_providers
     15: optional P2PInspectorSelector p2p_inspector
-    16: optional PaymentRoutingRuleset payment_routing_policies
+    16: optional PaymentRouting payment_routing
 
     // Deprecated
     5: optional ProviderSelector providers
@@ -2381,31 +2381,31 @@ struct ContractPaymentInstitutionDefaults {
 
 /* Routing rule sets */
 
-struct PaymentRoutingRuleset {
-    1: required RoutingRulesetRef allow
-    2: required RoutingRulesetRef deny
+struct PaymentRouting {
+    1: required PaymentRoutingRulesetRef policies
+    2: required PaymentRoutingRulesetRef prohobitions
 }
 
-struct RoutingRulesetRef { 1: required ObjectID id }
+struct PaymentRoutingRulesetRef { 1: required ObjectID id }
 
-struct RoutingRuleset {
+struct PaymentRoutingRuleset {
     1: required string name
     2: optional string description
-    3: required RoutingDecisions decisions
+    3: required PaymentRoutingDecisions decisions
 }
 
-union RoutingDecisions {
-    1: list<RoutingDelegate> delegates
-    2: list<RoutingCandidate> candidates
+union PaymentRoutingDecisions {
+    1: list<PaymentRoutingDelegate> delegates
+    2: list<PaymentRoutingCandidate> candidates
 }
 
-struct RoutingDelegate {
+struct PaymentRoutingDelegate {
     1: optional string description
     2: required Predicate allowed
-    3: required RoutingRulesetRef ruleset
+    3: required PaymentRoutingRulesetRef ruleset
 }
 
-struct RoutingCandidate {
+struct PaymentRoutingCandidate {
     1: optional string description
     2: required Predicate allowed
     3: required TerminalRef terminal
@@ -2574,9 +2574,9 @@ struct GlobalsObject {
     2: required Globals data
 }
 
-struct RoutingRulesObject {
-    1: required RoutingRulesetRef ref
-    2: required RoutingRuleset data
+struct PaymentRoutingRulesObject {
+    1: required PaymentRoutingRulesetRef ref
+    2: required PaymentRoutingRuleset data
 }
 
 union Reference {
@@ -2602,7 +2602,7 @@ union Reference {
     22 : WithdrawalProviderRef   withdrawal_provider
     23 : CashRegisterProviderRef cash_register_provider
     24 : P2PProviderRef          p2p_provider
-    26 : RoutingRulesetRef       routing_rules
+    26 : PaymentRoutingRulesetRef payment_routing_rules
     27 : WithdrawalTerminalRef    withdrawal_terminal
 
     12 : DummyRef                dummy
@@ -2635,7 +2635,7 @@ union DomainObject {
     22 : WithdrawalProviderObject   withdrawal_provider
     23 : CashRegisterProviderObject cash_register_provider
     24 : P2PProviderObject          p2p_provider
-    26 : RoutingRulesObject         routing_rules
+    26 : PaymentRoutingRulesObject  payment_routing_rules
     27 : WithdrawalTerminalObject   withdrawal_terminal
 
     12 : DummyObject                dummy

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2363,7 +2363,8 @@ struct PaymentInstitution {
     13: optional WithdrawalProviderSelector withdrawal_providers
     14: optional P2PProviderSelector p2p_providers
     15: optional P2PInspectorSelector p2p_inspector
-    16: optional PaymentRoutingRulesetRef payment_routing_ruleset
+    16: optional PaymentRoutingRulesetRef payment_routing_permissions
+    17: optional PaymentRoutingRulesetRef payment_routing_prohobitions
 
     // Deprecated
     5: optional ProviderSelector providers
@@ -2386,8 +2387,7 @@ struct PaymentRoutingRulesetRef { 1: required ObjectID id }
 struct PaymentRoutingRuleset {
     1: required string name
     2: optional string description
-    3: required PaymentRoutingDecisions permissions
-    4: required PaymentRoutingDecisions prohibitions
+    3: required PaymentRoutingDecisions decisions
 }
 
 union PaymentRoutingDecisions {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2363,8 +2363,7 @@ struct PaymentInstitution {
     13: optional WithdrawalProviderSelector withdrawal_providers
     14: optional P2PProviderSelector p2p_providers
     15: optional P2PInspectorSelector p2p_inspector
-    16: optional PaymentRoutingRulesetRef payment_routing_permissions
-    17: optional PaymentRoutingRulesetRef payment_routing_prohobitions
+    16: optional PaymentRoutingRuleset payment_routing_policies
 
     // Deprecated
     5: optional ProviderSelector providers
@@ -2382,26 +2381,31 @@ struct ContractPaymentInstitutionDefaults {
 
 /* Routing rule sets */
 
-struct PaymentRoutingRulesetRef { 1: required ObjectID id }
-
 struct PaymentRoutingRuleset {
+    1: required RoutingRulesetRef allow
+    2: required RoutingRulesetRef deny
+}
+
+struct RoutingRulesetRef { 1: required ObjectID id }
+
+struct RoutingRuleset {
     1: required string name
     2: optional string description
-    3: required PaymentRoutingDecisions decisions
+    3: required RoutingDecisions decisions
 }
 
-union PaymentRoutingDecisions {
-    1: list<PaymentRoutingDelegate> delegates
-    2: list<PaymentRoutingCandidate> candidates
+union RoutingDecisions {
+    1: list<RoutingDelegate> delegates
+    2: list<RoutingCandidate> candidates
 }
 
-struct PaymentRoutingDelegate {
+struct RoutingDelegate {
     1: optional string description
     2: required Predicate allowed
-    3: required PaymentRoutingRulesetRef ruleset
+    3: required RoutingRulesetRef ruleset
 }
 
-struct PaymentRoutingCandidate {
+struct RoutingCandidate {
     1: optional string description
     2: required Predicate allowed
     3: required TerminalRef terminal
@@ -2570,9 +2574,9 @@ struct GlobalsObject {
     2: required Globals data
 }
 
-struct PaymentRoutingRulesObject {
-    1: required PaymentRoutingRulesetRef ref
-    2: required PaymentRoutingRuleset data
+struct RoutingRulesObject {
+    1: required RoutingRulesetRef ref
+    2: required RoutingRuleset data
 }
 
 union Reference {
@@ -2598,7 +2602,7 @@ union Reference {
     22 : WithdrawalProviderRef   withdrawal_provider
     23 : CashRegisterProviderRef cash_register_provider
     24 : P2PProviderRef          p2p_provider
-    26 : PaymentRoutingRulesetRef payment_routing_rules
+    26 : RoutingRulesetRef       routing_rules
     27 : WithdrawalTerminalRef    withdrawal_terminal
 
     12 : DummyRef                dummy
@@ -2631,7 +2635,7 @@ union DomainObject {
     22 : WithdrawalProviderObject   withdrawal_provider
     23 : CashRegisterProviderObject cash_register_provider
     24 : P2PProviderObject          p2p_provider
-    26 : PaymentRoutingRulesObject  payment_routing_rules
+    26 : RoutingRulesObject         routing_rules
     27 : WithdrawalTerminalObject   withdrawal_terminal
 
     12 : DummyObject                dummy


### PR DESCRIPTION
Возникла идея выделить prohobitions в отдельный ruleset тк в пред. версии возможно появление странных правил. Когда в правилах для запрета возможно появление permission'ов.

Может permission/prohobitions заменить на allow_route/deny_route?