### PR TITLE
FF-200: Withdrawal adapter callbacks

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1944,13 +1944,15 @@ struct Provider {
     1: required string name
     2: required string description
     3: required Proxy proxy
-    /* Счет для платажей принятых эквайеромв АБС*/
-    5: required string abs_account
-    6: optional PaymentsProvisionTerms payment_terms
-    8: optional RecurrentPaytoolsProvisionTerms recurrent_paytool_terms
+    9: optional string identity
     7: optional ProviderAccountSet accounts = {}
+    10: optional ProvisionTermSet terms
+    11: optional list<ProviderParameter> params_schema
 
     // Deprecated
+    5: optional string abs_account
+    6: optional PaymentsProvisionTerms payment_terms
+    8: optional RecurrentPaytoolsProvisionTerms recurrent_paytool_terms
     4: optional TerminalSelector terminal
 }
 
@@ -1959,28 +1961,28 @@ struct CashRegisterProviderRef { 1: required ObjectID id }
 struct CashRegisterProvider {
     1: required string                              name
     2: optional string                              description
-    3: required list<CashRegisterProviderParameter> params_schema
+    3: required list<ProviderParameter>             params_schema
     4: required Proxy                               proxy
 }
 
-struct CashRegisterProviderParameter {
+struct ProviderParameter {
     1: required string                            id
     2: optional string                            description
-    3: required CashRegisterProviderParameterType type
+    3: required ProviderParameterType             type
     4: required bool                              is_required
 }
 
-union CashRegisterProviderParameterType {
-    1: CashRegisterProviderParameterString   string_type
-    2: CashRegisterProviderParameterInteger  integer_type
-    3: CashRegisterProviderParameterUrl      url_type
-    4: CashRegisterProviderParameterPassword password_type
+union ProviderParameterType {
+    1: ProviderParameterString   string_type
+    2: ProviderParameterInteger  integer_type
+    3: ProviderParameterUrl      url_type
+    4: ProviderParameterPassword password_type
 }
 
-struct CashRegisterProviderParameterString {}
-struct CashRegisterProviderParameterInteger {}
-struct CashRegisterProviderParameterUrl {}
-struct CashRegisterProviderParameterPassword {}
+struct ProviderParameterString {}
+struct ProviderParameterInteger {}
+struct ProviderParameterUrl {}
+struct ProviderParameterPassword {}
 
 struct WithdrawalProviderRef { 1: required ObjectID id }
 
@@ -2003,6 +2005,12 @@ struct P2PProvider {
     4: optional string identity
     6: optional P2PProvisionTerms p2p_terms
     7: optional ProviderAccountSet accounts = {}
+}
+
+struct ProvisionTermSet {
+    1: optional PaymentsProvisionTerms payments
+    2: optional RecurrentPaytoolsProvisionTerms recurrent_paytools
+    3: optional WalletProvisionTerms wallet
 }
 
 struct PaymentsProvisionTerms {
@@ -2045,6 +2053,12 @@ struct RecurrentPaytoolsProvisionTerms {
     1: required CashValueSelector     cash_value
     2: required CategorySelector      categories
     3: required PaymentMethodSelector payment_methods
+}
+
+struct WalletProvisionTerms {
+    1: optional CumulativeLimitSelector turnover_limit
+    2: optional WithdrawalProvisionTerms withdrawals
+    3: optional P2PProvisionTerms p2p
 }
 
 struct WithdrawalProvisionTerms {
@@ -2157,9 +2171,12 @@ struct Terminal {
     1: required string name
     2: required string description
     9: optional ProxyOptions options
-    10: required RiskScore risk_coverage
-    12: optional PaymentsProvisionTerms terms
+    10: optional RiskScore risk_coverage
     13: optional ProviderRef provider_ref
+    14: optional ProvisionTermSet terms
+
+    // deprecated
+    12: optional PaymentsProvisionTerms terms_legacy
 }
 
 union TerminalSelector {
@@ -2398,12 +2415,14 @@ struct PaymentInstitution {
     /* TODO: separated system accounts for wallets look weird */
     11: optional SystemAccountSetSelector wallet_system_account_set
     12: optional string identity
-    13: optional WithdrawalProviderSelector withdrawal_providers
-    14: optional P2PProviderSelector p2p_providers
     15: optional P2PInspectorSelector p2p_inspector
     16: optional PaymentRouting payment_routing
+    17: optional ProviderSelector withdrawal_providers
+    18: optional ProviderSelector p2p_providers
 
     // Deprecated
+    13: optional WithdrawalProviderSelector withdrawal_providers_legacy
+    14: optional P2PProviderSelector p2p_providers_legacy
     5: optional ProviderSelector providers
 }
 

--- a/proto/withdrawals_provider_adapter.thrift
+++ b/proto/withdrawals_provider_adapter.thrift
@@ -2,6 +2,7 @@ include "base.thrift"
 include "msgpack.thrift"
 include "domain.thrift"
 include "withdrawals_domain.thrift"
+include "timeout_behaviour.thrift"
 
 namespace java com.rbkmoney.damsel.withdrawals.provider_adapter
 namespace erlang wthadpt

--- a/proto/withdrawals_provider_adapter.thrift
+++ b/proto/withdrawals_provider_adapter.thrift
@@ -2,7 +2,6 @@ include "base.thrift"
 include "msgpack.thrift"
 include "domain.thrift"
 include "withdrawals_domain.thrift"
-include "timeout_behaviour.thrift"
 
 namespace java com.rbkmoney.damsel.withdrawals.provider_adapter
 namespace erlang wthadpt


### PR DESCRIPTION
Пара непонятных моментов:
1. Нужен ли механизм `AdapterHost`? Аналогично платежному `ProviderProxyHost`. Как я понимаю, могут быть два сценария, и когда процессинг "засыпает", а потом по пробуждению идет в адаптер сам, и когда адаптер должен сам его "разбудить" вызовом на `AdapterHost`, иначе сессия зафейлится по таймауту.
1. И если да, то где лучше жить его протоколу, тут или в `ff-proto`?