### PR TITLE
DC-129 Allow to define more flexible conditions in provision terms

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2065,6 +2065,7 @@ struct ProvisionTermSet {
 }
 
 struct PaymentsProvisionTerms {
+    11: optional Predicate allow
     1: optional CurrencySelector currencies
     2: optional CategorySelector categories
     3: optional PaymentMethodSelector payment_methods
@@ -2113,6 +2114,7 @@ struct WalletProvisionTerms {
 }
 
 struct WithdrawalProvisionTerms {
+    5: optional Predicate allow
     1: optional CurrencySelector currencies
     2: optional PayoutMethodSelector payout_methods
     3: optional CashLimitSelector cash_limit
@@ -2120,6 +2122,7 @@ struct WithdrawalProvisionTerms {
 }
 
 struct P2PProvisionTerms {
+    5: optional Predicate allow
     1: optional CurrencySelector currencies
     2: optional CashLimitSelector cash_limit
     3: optional CashFlowSelector cash_flow


### PR DESCRIPTION
Было высказано сожаление о сложности указания условий вида "Никогда не направляй платежи с картой из страны С в провайдера П". Кажется, что тут применим подход, который мы использовали при задании мерчантских условий в кошельковых операциях.