### PR TITLE
MSPF-565: Add external terminal id to events

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -325,6 +325,7 @@ struct ClientInfo {
 struct PaymentRoute {
     1: required ProviderRef provider
     2: required TerminalRef terminal
+    3: optional ExternalTerminalID external_terminal_id
 }
 
 struct RecurrentParentPayment {


### PR DESCRIPTION
Не очень понимаю, где таким данным имеет место быть. Если терминал ид наверное может и быть в роуте, то куда поместить merchantID и MCC вообще не представляю, но вроде как и задачи на них не было.