### PR TITLE
CAPI-430: Add last_transaction_info to payproc_InvoicePayment struct

### DIFF
--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -620,7 +620,7 @@ struct InvoicePayment {
     4: required list<InvoicePaymentRefund> refunds
     5: required list<InvoicePaymentSession> sessions
     8: optional list<InvoicePaymentChargeback> chargebacks
-    9: optional domain.AdditionalTransactionInfo additional_transaction_info
+    9: optional domain.TransactionInfo last_transaction_info
     # deprecated
     3: required list<domain.InvoicePaymentRefund> legacy_refunds
 }

--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -620,6 +620,7 @@ struct InvoicePayment {
     4: required list<InvoicePaymentRefund> refunds
     5: required list<InvoicePaymentSession> sessions
     8: optional list<InvoicePaymentChargeback> chargebacks
+    9: optional domain.AdditionalTransactionInfo additional_transaction_info
     # deprecated
     3: required list<domain.InvoicePaymentRefund> legacy_refunds
 }


### PR DESCRIPTION
Adding `additional_transaction_info` field to `payproc_InvoicePayment`, replicating the way its done in [`merchstat_StatPayment`](https://github.com/rbkmoney/damsel/blob/bc366eb3d381368e3419a3bb05fb9bd7e9630337/proto/merch_stat.thrift#L33).