### PR TITLE
DC-130: remove duplicate types fields in DomainObject and Reference unions

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2776,7 +2776,7 @@ union Reference {
     22 : WithdrawalProviderRef      withdrawal_provider
     23 : CashRegisterProviderRef    cash_register_provider
     24 : P2PProviderRef             p2p_provider
-    26 : RoutingRulesetRef          payment_routing_rules
+    26 : RoutingRulesetRef          routing_ruleset
     27 : WithdrawalTerminalRef      withdrawal_terminal
     28 : BankCardCategoryRef        bank_card_category
     29 : CriterionRef               criterion
@@ -2812,7 +2812,7 @@ union DomainObject {
     22 : WithdrawalProviderObject   withdrawal_provider
     23 : CashRegisterProviderObject cash_register_provider
     24 : P2PProviderObject          p2p_provider
-    26 : RoutingRulesObject         payment_routing_rules
+    26 : RoutingRulesObject         routing_rules
     27 : WithdrawalTerminalObject   withdrawal_terminal
     28 : BankCardCategoryObject     bank_card_category
     29 : CriterionObject            criterion

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2780,7 +2780,7 @@ union Reference {
     27 : WithdrawalTerminalRef      withdrawal_terminal
     28 : BankCardCategoryRef        bank_card_category
     29 : CriterionRef               criterion
-    30 : DocumentTypeRef            document_type
+    32 : DocumentTypeRef            document_type
 
     12 : DummyRef                   dummy
     13 : DummyLinkRef               dummy_link
@@ -2816,7 +2816,7 @@ union DomainObject {
     27 : WithdrawalTerminalObject   withdrawal_terminal
     28 : BankCardCategoryObject     bank_card_category
     29 : CriterionObject            criterion
-    30 : DocumentTypeObject         document_type
+    32 : DocumentTypeObject         document_type
 
     12 : DummyObject                dummy
     13 : DummyLinkObject            dummy_link

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2777,12 +2777,10 @@ union Reference {
     23 : CashRegisterProviderRef    cash_register_provider
     24 : P2PProviderRef             p2p_provider
     26 : RoutingRulesetRef          payment_routing_rules
-    30 : RoutingRulesetRef          withdrawal_routing_rules
-    31 : RoutingRulesetRef          p2p_transfer_routing_rules
     27 : WithdrawalTerminalRef      withdrawal_terminal
     28 : BankCardCategoryRef        bank_card_category
     29 : CriterionRef               criterion
-    32 : DocumentTypeRef            document_type
+    30 : DocumentTypeRef            document_type
 
     12 : DummyRef                   dummy
     13 : DummyLinkRef               dummy_link
@@ -2815,12 +2813,10 @@ union DomainObject {
     23 : CashRegisterProviderObject cash_register_provider
     24 : P2PProviderObject          p2p_provider
     26 : RoutingRulesObject         payment_routing_rules
-    30 : RoutingRulesObject         withdrawal_routing_rules
-    31 : RoutingRulesObject         p2p_transfer_routing_rules
     27 : WithdrawalTerminalObject   withdrawal_terminal
     28 : BankCardCategoryObject     bank_card_category
     29 : CriterionObject            criterion
-    32 : DocumentTypeObject         document_type
+    30 : DocumentTypeObject         document_type
 
     12 : DummyObject                dummy
     13 : DummyLinkObject            dummy_link


### PR DESCRIPTION
Вопрос: нужно ли переименовывать поле payment_routing_rules в DomainObject/Reference юнионах в routing_rules?