### PR TITLE
inspector: make_recurrent flag

### DIFF
--- a/proto/proxy_inspector.thrift
+++ b/proto/proxy_inspector.thrift
@@ -38,6 +38,7 @@ struct InvoicePayment {
     2: required base.Timestamp created_at
     3: required domain.Payer payer
     4: required domain.Cash cost
+    5: optional bool make_recurrent
 }
 
 struct Invoice {


### PR DESCRIPTION
передача флага makeRecurrent из [createPayment](https://developer.rbk.money/api/#operation/createPayment) инспектору в InvoicePayment, как признак прямого рекуррента. 
