### PR TITLE
Add payment and bank card validation rules

### DIFF
--- a/proto/base.thrift
+++ b/proto/base.thrift
@@ -209,5 +209,5 @@ exception InvalidRequest {
 **/
 struct IntegerRange {
     1: optional i64 lower
-    2: optional i16 upper
+    2: optional i64 upper
 }

--- a/proto/base.thrift
+++ b/proto/base.thrift
@@ -208,6 +208,6 @@ exception InvalidRequest {
 * Диапазон допустимых целых значений, lower =< upper.
 **/
 struct IntegerRange {
-    1: optional i16 lower
+    1: optional i64 lower
     2: optional i16 upper
 }

--- a/proto/base.thrift
+++ b/proto/base.thrift
@@ -203,3 +203,11 @@ exception InvalidRequest {
     /** Список пригодных для восприятия человеком ошибок во входных данных */
     1: required list<string> errors
 }
+
+/**
+* Диапазон допустимых целых значений, lower =< upper.
+**/
+struct IntegerRange {
+    1: optional i16 lower
+    2: optional i16 upper
+}

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1604,6 +1604,8 @@ struct PaymentSystemRef {
 struct PaymentSystem {
   1: required string name
   2: optional string description
+  3: optional list<string> patterns
+  4: optional list<PaymentCardElement> card_params
 }
 
 /** Тип платежного токена **/
@@ -1798,10 +1800,75 @@ struct Bank {
     1: required string name
     2: required string description
     4: optional set<string> binbase_id_patterns
+    5: optional list<BankCardElement> card_params
 
     /* legacy */
     3: required set<string> bins
 }
+
+union BankCardElement {
+    1: PaymentCardNumber card_number
+    2: BankCardExpirationDate exp_date
+    3: PaymentCardCVC cvc
+}
+
+union BankCardExpirationDate {
+    1: PaymentCardExactExpirationDate exact_exp_date
+    2: PaymentCardExtendedExpirationDate extended_exp_date
+}
+
+union PaymentCardExtendedExpirationDate {
+    1: required PaymentCardAbsoluteExpirationDate absolute_exp_date
+    2: required PaymentCardRelativeExpirationDate relative_exp_date
+}
+
+struct PaymentCardAbsoluteExpirationDate {
+    /** Месяц 1..12 */
+    1: required i8 month
+    /** Год 2015..∞ */
+    2: required i16 year
+}
+
+struct PaymentCardRelativeExpirationDate {
+    1: required i8 delta_days
+}
+
+union PaymentCardElement {
+    1: PaymentCardNumber card_number
+    2: PaymentCardExpirationDate exp_date
+    3: PaymentCardCVC cvc
+}
+
+struct PaymentCardNumber {
+    1: required list<PaymentCardElementLength> length
+    2: optional PaymentCardNumberVerifyAlgorithm verify_algorithm
+}
+
+union PaymentCardNumberVerifyAlgorithm {
+    1: PaymentCardNumberVerifyAlgorithmLuhn luhn
+}
+
+struct PaymentCardNumberVerifyAlgorithmLuhn {}
+
+union PaymentCardElementLength {
+    1: i8 length
+    2: PaymentCardElementLengthRange range
+}
+
+struct PaymentCardElementLengthRange {
+    1: required i8 from
+    2: required i8 to
+}
+
+struct PaymentCardCVC {
+    1: required PaymentCardElementLength length
+}
+
+union PaymentCardExpirationDate {
+    1: PaymentCardExactExpirationDate exact_exp_date
+}
+
+struct PaymentCardExactExpirationDate {}
 
 struct PaymentMethodRef { 1: required PaymentMethod id }
 

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1800,21 +1800,10 @@ struct Bank {
     1: required string name
     2: required string description
     4: optional set<string> binbase_id_patterns
-    5: optional list<BankCardElement> card_params
+    5: optional list<PaymentCardElement> card_params
 
     /* legacy */
     3: required set<string> bins
-}
-
-union BankCardElement {
-    1: PaymentCardNumber card_number
-    2: BankCardExpirationDate exp_date
-    3: PaymentCardCVC cvc
-}
-
-union BankCardExpirationDate {
-    1: PaymentCardExactExpirationDate exact_exp_date
-    2: PaymentCardExtendedExpirationDate extended_exp_date
 }
 
 union PaymentCardExtendedExpirationDate {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1604,8 +1604,7 @@ struct PaymentSystemRef {
 struct PaymentSystem {
   1: required string name
   2: optional string description
-  3: optional list<string> patterns
-  4: optional list<PaymentCardElement> card_params
+  3: optional list<PaymentCardElement> card_params
 }
 
 /** Тип платежного токена **/
@@ -2479,20 +2478,12 @@ union Condition {
     7: PayoutMethodRef payout_method_is
     8: ContractorIdentificationLevel identification_level_is
     9: P2PToolCondition p2p_tool
-   10: PaymentSystemCondition payment_system
+   10: BinDataCondition bin_data
 }
 
-union PaymentSystemCondition {
-    1: PaymentSystemMatches matches
-    2: PaymentSystemEquals equals
-}
-
-struct PaymentSystemMatches {
-    1: required set<string> values
-}
-
-struct PaymentSystemEquals {
-    1: required set<string> values
+union BinDataCondition {
+    1: string payment_system_matches
+    2: string payment_system_equals
 }
 
 struct P2PToolCondition {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2481,9 +2481,14 @@ union Condition {
    10: BinDataCondition bin_data
 }
 
-union BinDataCondition {
-    1: string payment_system_matches
-    2: string payment_system_equals
+struct BinDataCondition {
+    1: optional StringCondition payment_system
+    2: optional StringCondition bank_name
+}
+
+union StringCondition {
+    1: string matches
+    2: string equals
 }
 
 struct P2PToolCondition {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1604,7 +1604,7 @@ struct PaymentSystemRef {
 struct PaymentSystem {
   1: required string name
   2: optional string description
-  3: optional list<PaymentCardValidationRule> card_params
+  3: optional list<PaymentCardValidationRule> validation_rules
 }
 
 /** Тип платежного токена **/

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2511,13 +2511,13 @@ struct BankCardCondition {
 union BankCardConditionDefinition {
     1: LegacyBankCardPaymentSystem payment_system_is // deprecated
     2: BankRef issuer_bank_is
-    3: BankCardPaymentSystemCondition payment_system
+    3: PaymentSystemCondition payment_system
     4: Residence issuer_country_is
     5: bool empty_cvv_is
     6: BankCardCategoryRef category_is
 }
 
-struct BankCardPaymentSystemCondition {
+struct PaymentSystemCondition {
     4: optional PaymentSystemRef      payment_system_is
     5: optional BankCardTokenServiceRef payment_token_is
     3: optional TokenizationMethod    tokenization_method_is

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1811,7 +1811,7 @@ union PaymentCardValidationRule {
 }
 
 union PaymentCardNumber {
-    1: base.IntegerRange range
+    1: set<base.IntegerRange> ranges
     2: PaymentCardNumberChecksum checksum
 }
 

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1812,7 +1812,7 @@ struct PaymentCardRedefinedExpirationDate {
 }
 
 struct PaymentCardRelativeExpirationDate {
-    1: required i8 delta_days
+    1: required i16 delta_days
 }
 
 union PaymentCardElement {
@@ -1822,7 +1822,7 @@ union PaymentCardElement {
 }
 
 struct PaymentCardNumber {
-    1: required list<PaymentCardElementLength> length
+    1: required list<base.IntegerRange> length
     2: optional PaymentCardNumberVerifyAlgorithm verify_algorithm
 }
 
@@ -1832,18 +1832,9 @@ union PaymentCardNumberVerifyAlgorithm {
 
 struct PaymentCardNumberVerifyAlgorithmLuhn {}
 
-union PaymentCardElementLength {
-    1: i8 length
-    2: PaymentCardElementLengthRange range
-}
-
-struct PaymentCardElementLengthRange {
-    1: required i8 start
-    2: required i8 finish
-}
 
 struct PaymentCardCVC {
-    1: required PaymentCardElementLength length
+    1: required base.IntegerRange length
 }
 
 union PaymentCardExpirationDate {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1807,11 +1807,11 @@ struct Bank {
 }
 
 union PaymentCardExtendedExpirationDate {
-    1: PaymentCardAbsoluteExpirationDate absolute_exp_date
+    1: PaymentCardRedefinedExpirationDate redefined_exp_date
     2: PaymentCardRelativeExpirationDate relative_exp_date
 }
 
-struct PaymentCardAbsoluteExpirationDate {
+struct PaymentCardRedefinedExpirationDate {
     /** Месяц 1..12 */
     1: required i8 month
     /** Год 2015..∞ */

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1818,8 +1818,8 @@ union BankCardExpirationDate {
 }
 
 union PaymentCardExtendedExpirationDate {
-    1: required PaymentCardAbsoluteExpirationDate absolute_exp_date
-    2: required PaymentCardRelativeExpirationDate relative_exp_date
+    1: PaymentCardAbsoluteExpirationDate absolute_exp_date
+    2: PaymentCardRelativeExpirationDate relative_exp_date
 }
 
 struct PaymentCardAbsoluteExpirationDate {
@@ -1856,8 +1856,8 @@ union PaymentCardElementLength {
 }
 
 struct PaymentCardElementLengthRange {
-    1: required i8 from
-    2: required i8 to
+    1: required i8 begin
+    2: required i8 end
 }
 
 struct PaymentCardCVC {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1604,7 +1604,7 @@ struct PaymentSystemRef {
 struct PaymentSystem {
   1: required string name
   2: optional string description
-  3: optional list<PaymentCardValidationRule> validation_rules
+  3: optional set<PaymentCardValidationRule> validation_rules
 }
 
 /** Тип платежного токена **/

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1604,7 +1604,7 @@ struct PaymentSystemRef {
 struct PaymentSystem {
   1: required string name
   2: optional string description
-  3: optional list<PaymentCardElement> card_params
+  3: optional list<PaymentCardValidationRule> card_params
 }
 
 /** Тип платежного токена **/
@@ -1804,33 +1804,22 @@ struct Bank {
     3: required set<string> bins
 }
 
-struct PaymentCardRedefinedExpirationDate {
-    /** Месяц 1..12 */
-    1: required i8 month
-    /** Год 2015..∞ */
-    2: required i16 year
-}
-
-struct PaymentCardRelativeExpirationDate {
-    1: required i16 delta_days
-}
-
-union PaymentCardElement {
+union PaymentCardValidationRule {
     1: PaymentCardNumber card_number
     2: PaymentCardExpirationDate exp_date
     3: PaymentCardCVC cvc
 }
 
-struct PaymentCardNumber {
-    1: required list<base.IntegerRange> length
-    2: optional PaymentCardNumberVerifyAlgorithm verify_algorithm
+union PaymentCardNumber {
+    1: base.IntegerRange range
+    2: PaymentCardNumberChecksum checksum
 }
 
-union PaymentCardNumberVerifyAlgorithm {
-    1: PaymentCardNumberVerifyAlgorithmLuhn luhn
+union PaymentCardNumberChecksum {
+    1: PaymentCardNumberChecksumLuhn luhn
 }
 
-struct PaymentCardNumberVerifyAlgorithmLuhn {}
+struct PaymentCardNumberChecksumLuhn {}
 
 
 struct PaymentCardCVC {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1800,15 +1800,9 @@ struct Bank {
     1: required string name
     2: required string description
     4: optional set<string> binbase_id_patterns
-    5: optional list<PaymentCardElement> card_params
 
     /* legacy */
     3: required set<string> bins
-}
-
-union PaymentCardExtendedExpirationDate {
-    1: PaymentCardRedefinedExpirationDate redefined_exp_date
-    2: PaymentCardRelativeExpirationDate relative_exp_date
 }
 
 struct PaymentCardRedefinedExpirationDate {
@@ -2310,6 +2304,16 @@ struct ProviderAccount {
     1: required AccountID settlement
 }
 
+union PaymentSystemSelector {
+    1: list<PaymentSystemDecision> decisions
+    2: PaymentSystemRef value
+}
+
+struct PaymentSystemDecision {
+    1: required Predicate if_
+    2: required PaymentSystemSelector then_
+}
+
 union ProviderSelector {
     1: list<ProviderDecision> decisions
     2: set<ProviderRef> value
@@ -2475,6 +2479,20 @@ union Condition {
     7: PayoutMethodRef payout_method_is
     8: ContractorIdentificationLevel identification_level_is
     9: P2PToolCondition p2p_tool
+   10: PaymentSystemCondition payment_system
+}
+
+union PaymentSystemCondition {
+    1: PaymentSystemMatches matches
+    2: PaymentSystemEquals equals
+}
+
+struct PaymentSystemMatches {
+    1: required set<string> values
+}
+
+struct PaymentSystemEquals {
+    1: required set<string> values
 }
 
 struct P2PToolCondition {
@@ -2497,13 +2515,13 @@ struct BankCardCondition {
 union BankCardConditionDefinition {
     1: LegacyBankCardPaymentSystem payment_system_is // deprecated
     2: BankRef issuer_bank_is
-    3: PaymentSystemCondition payment_system
+    3: BankCardPaymentSystemCondition payment_system
     4: Residence issuer_country_is
     5: bool empty_cvv_is
     6: BankCardCategoryRef category_is
 }
 
-struct PaymentSystemCondition {
+struct BankCardPaymentSystemCondition {
     4: optional PaymentSystemRef      payment_system_is
     5: optional BankCardTokenServiceRef payment_token_is
     3: optional TokenizationMethod    tokenization_method_is
@@ -2667,6 +2685,7 @@ struct PaymentInstitution {
     20: optional RoutingRules p2p_transfer_routing_rules
     17: optional ProviderSelector withdrawal_providers
     18: optional ProviderSelector p2p_providers
+    21: optional PaymentSystemSelector payment_system
 
     // Deprecated
     13: optional WithdrawalProviderSelector withdrawal_providers_legacy

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1822,7 +1822,7 @@ union PaymentCardNumberChecksum {
 struct PaymentCardNumberChecksumLuhn {}
 
 
-struct PaymentCardCVC {
+union PaymentCardCVC {
     1: required base.IntegerRange length
 }
 

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1823,7 +1823,7 @@ struct PaymentCardNumberChecksumLuhn {}
 
 
 union PaymentCardCVC {
-    1: required base.IntegerRange length
+    1: base.IntegerRange length
 }
 
 union PaymentCardExpirationDate {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1856,8 +1856,8 @@ union PaymentCardElementLength {
 }
 
 struct PaymentCardElementLengthRange {
-    1: required i8 begin
-    2: required i8 end
+    1: required i8 start
+    2: required i8 finish
 }
 
 struct PaymentCardCVC {


### PR DESCRIPTION
Попробовал собрать всё в кучу :)

### Платежные системы

Платежные карты привязаны к и используются с какой-то платежной системой, различают международные и национальные платёжные системы.

### Платёжных карты

На рынке различают следующие виды платёжных карт (обобщенно):
 - Банковские
 - Дебетовые
 - Кредитные
 - Предоплатные
 - ...

У нас используются только банковские, остальные либо подразумеваются (дебетовые, кредитные как варианты банковских), либо не используются.

Платежные карты содержит следующие значимые элементы:
 - Номер карты
 - Срок действия
 - CVC

К перечисленным выше элементам применяются правила валидации
 - Для номера карты
    - состоит из цифр
 - Для CVC
    - состоит из цифр
    - длина номера, несколько вариантов или диапазон
 - Срок действия
 	- Состоит из цифр, кодирующих последний месяц и год срока действия

В зависимости от платёжной сиситемы на элементы могут налагаться дополнительные правила валидации
 - Для номера карты
 	- один или несколько вариантов длины или диапазон допустимых длин номера
 	- контроль валидности номера (luhn, у других типов могут быть иные, но мы их не поддерживаем в настоящий момент) 
 - CVC
 	- может отсутствовать

Так же правила валидации могут носить постоянный или временный характер, например, для ряда банковских карт применялись смягчающие правила валидации на период локдауна (теоретически может повториться при других условиях)
 - Срок действия
 	- В зависимости от банка-эмитента действие карты с невалидным сроком действия продлевалось на некоторый срок (сейчас параметр в конфиге, который представляет некий обобщенный диапазон, не отражающий в полной мере требования)

Кажется, все эти условия можно свести воедино с помощью нескольких дополнительных структур, вытащив тем самым условия проверки из кода в конфиг (этим кстати решим так же кейсы, когда надо поправить что-то, например, добавить условия для номеров карт и/или CVC).

В итоге выбор платёжной системы и банка идёт по паттернам из `PaymentSystem` и `Bank`, применяемым к данным, полученным из `Binbase` по PAN. Полученные правила сливаются поэлементно, при этом правила банка имеют приоритет над правилами платёжной системы (тем самым позволяя конкретизировать общие положения).
