### PR TITLE
BUSINESS-134: support split payments in hooker

### DIFF
--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -629,6 +629,7 @@ struct InvoicePayment {
     5: required list<InvoicePaymentSession> sessions
     8: optional list<InvoicePaymentChargeback> chargebacks
     9: optional domain.TransactionInfo last_transaction_info
+    11: optional domain.Allocation allocaton
     # deprecated
     3: required list<domain.InvoicePaymentRefund> legacy_refunds
 }


### PR DESCRIPTION
Для поддержки сплитов в hooker необходимо расширить `Invoice Get (1: UserInfo user, 2: domain.InvoiceID id, 3: EventRange range)`, чтобы на capture отдавать allocation.