### PR TITLE
JD-540: add INN to RussianPrivateEntity

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -880,7 +880,7 @@ struct RussianPrivateEntity {
     2: required string second_name
     3: required string middle_name
     4: required ContactInfo contact_info
-    5: required string inn;
+    5: required string inn
 }
 
 typedef base.ID PayoutToolID

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -880,6 +880,7 @@ struct RussianPrivateEntity {
     2: required string second_name
     3: required string middle_name
     4: required ContactInfo contact_info
+    5: required string inn;
 }
 
 typedef base.ID PayoutToolID


### PR DESCRIPTION
Для обеспечения уникальности клиентов нам необходимо ИНН в RussianPrivateEntity.
Субъективно, выглядит так будто его забыли включить в модель, в остальных, специфических для России, сущностях он есть.
Если его там быть не должно, то прошу объяснить в чем не прав :)