### PR TITLE
ED-293/reduce-compute-varset

### DIFF
--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -1973,6 +1973,17 @@ struct Varset {
     12: optional domain.BinData bin_data
 }
 
+struct ComputeShopTermsVarset {
+    1: optional domain.Cash amount
+    /* seems not used */
+    2: optional domain.PaymentMethodRef payment_method
+    3: optional domain.PayoutMethodRef payout_method
+    4: optional domain.WalletID wallet_id
+    5: optional domain.PaymentTool payment_tool
+    6: optional domain.BinData bin_data
+}
+
+
 struct PartyParams {
     1: required domain.PartyContactInfo contact_info
 }
@@ -2566,7 +2577,7 @@ service PartyManagement {
         3: ShopID id,
         4: base.Timestamp timestamp
         5: PartyRevisionParam party_revision
-        6: Varset varset
+        6: ComputeShopTermsVarset varset
     )
         throws (
             1: InvalidUser ex1,

--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -2527,10 +2527,6 @@ exception GlobalsNotFound {}
 
 exception RuleSetNotFound {}
 
-exception VarsetPartyNotMatch {
-    1: required PartyID varset_party_id
-    2: required PartyID agrument_party_id
-}
 
 // Service
 
@@ -2603,8 +2599,7 @@ service PartyManagement {
             1: InvalidUser ex1,
             2: PartyNotFound ex2,
             3: PartyNotExistsYet ex3
-            4: ContractNotFound ex4,
-            5: VarsetPartyNotMatch ex5
+            4: ContractNotFound ex4
         )
 
     /* Shop */
@@ -2639,8 +2634,7 @@ service PartyManagement {
             1: InvalidUser ex1,
             2: PartyNotFound ex2,
             3: PartyNotExistsYet ex3,
-            4: ShopNotFound ex4,
-            5: VarsetPartyNotMatch ex5
+            4: ShopNotFound ex4
         )
 
     /* Claim */

--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -1974,13 +1974,13 @@ struct Varset {
 }
 
 struct ComputeShopTermsVarset {
-    1: optional domain.Cash amount
+    3: optional domain.Cash amount
     /* seems not used */
-    2: optional domain.PaymentMethodRef payment_method
-    3: optional domain.PayoutMethodRef payout_method
-    4: optional domain.WalletID wallet_id
-    5: optional domain.PaymentTool payment_tool
-    6: optional domain.BinData bin_data
+    4: optional domain.PaymentMethodRef payment_method
+    5: optional domain.PayoutMethodRef payout_method
+    6: optional domain.WalletID wallet_id
+    10: optional domain.PaymentTool payment_tool
+    12: optional domain.BinData bin_data
 }
 
 

--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -1975,11 +1975,24 @@ struct Varset {
 
 struct ComputeShopTermsVarset {
     3: optional domain.Cash amount
+
     /* seems not used */
     4: optional domain.PaymentMethodRef payment_method
     5: optional domain.PayoutMethodRef payout_method
     6: optional domain.WalletID wallet_id
     10: optional domain.PaymentTool payment_tool
+    12: optional domain.BinData bin_data
+}
+
+struct ComputeContractTermsVarset {
+    3: optional domain.Cash amount
+    8: optional domain.ShopID shop_id
+    10: optional domain.PaymentTool payment_tool
+
+    /* fistful */
+    4: optional domain.PaymentMethodRef payment_method
+    5: optional domain.PayoutMethodRef payout_method
+    6: optional domain.WalletID wallet_id
     12: optional domain.BinData bin_data
 }
 
@@ -2541,7 +2554,7 @@ service PartyManagement {
         4: base.Timestamp timestamp
         5: PartyRevisionParam party_revision
         6: domain.DataRevision domain_revision
-        7: Varset varset
+        7: ComputeContractTermsVarset varset
     )
         throws (
             1: InvalidUser ex1,

--- a/proto/payment_processing.thrift
+++ b/proto/payment_processing.thrift
@@ -2026,23 +2026,15 @@ struct Varset {
 
 struct ComputeShopTermsVarset {
     3: optional domain.Cash amount
-
-    /* seems not used */
-    4: optional domain.PaymentMethodRef payment_method
     5: optional domain.PayoutMethodRef payout_method
-    6: optional domain.WalletID wallet_id
     10: optional domain.PaymentTool payment_tool
-    12: optional domain.BinData bin_data
 }
 
 struct ComputeContractTermsVarset {
     3: optional domain.Cash amount
     8: optional domain.ShopID shop_id
-    10: optional domain.PaymentTool payment_tool
-
-    /* fistful */
-    4: optional domain.PaymentMethodRef payment_method
     5: optional domain.PayoutMethodRef payout_method
+    10: optional domain.PaymentTool payment_tool
     6: optional domain.WalletID wallet_id
     12: optional domain.BinData bin_data
 }
@@ -2649,24 +2641,6 @@ service PartyManagement {
             3: PartyNotExistsYet ex3,
             4: ShopNotFound ex4,
             5: VarsetPartyNotMatch ex5
-        )
-
-    /* Wallet */
-
-    // deprecated
-    // do not use
-    domain.TermSet ComputeWalletTermsNew (
-        1: UserInfo user,
-        2: PartyID party_id,
-        3: ContractID contract_id,
-        4: base.Timestamp timestamp
-        5: Varset varset
-    )
-        throws (
-            1: InvalidUser ex1,
-            2: PartyNotFound ex2,
-            3: PartyNotExistsYet ex3,
-            4: VarsetPartyNotMatch ex4
         )
 
     /* Claim */


### PR DESCRIPTION
Описание задачи ([ED-239](https://rbkmoney.atlassian.net/browse/ED-293)), имхо, не вполне соответствует действительности: на уровне кода party-management описываемый конфликт решается при несоответствии идентификаторов party-id в параметре функции (ComputeContractTerms) и Varset'e кидается исключение VarsetPartyNotMatch. Для ShopID аналогичной проверки нет (ф-ция ComputeShopTerms). Но противоречие остаётся в протоколе.

При просмотре остальных параметров Varset'a нашёл, что часть из них восстанавливаются из объектов Party и Shop:
* category (Shop#domain_Shop.category)
* currency ((Shop#domain_Shop.account)#domain_ShopAccount.currency)
* identification_level (Contract & Party)

А часть не заполняется на клиенте (hellgate):
* payment_method
* payout_method
* wallet_id
* payment_tool
* bin_data

По логам, кроме hellgate, никто функции ComputeShopTerms и ComputeContractTerms не дёргает. Ф-ция ComputeWalletTermsNew помечена как устаревшая и в party-client её вызова даже нет. Посмотрел код fistful-server это справедливо для ComputeShopTerms, для ComputeContractTerms они (кроме payment_method) заполняются (withdrawal).

Из параметров Varset остаётся только cost, который берётся из Invoice в стейте hellgate'a. @ndiezel0 отклонил идею убрать структуру Varset'a (с заменой её на cost) из ф-ций ComputeContractTerms, ComputeShopTerms под возможное дальнейшее расширение. Не заполняемые поля (см. выше) пока решили оставить.

Порядок обновление:
1) При старом протоколе обновляю PM, проигнорировав удалённые в новом протоколе поля и
восстановив нехватающие значения из имеющихся
1.б) Не забыть удилить исключение VarsetPartyNotMatch из протокола
2) Меняю клиенты в соответствии с обновлённым протоколом
2.б) Не забыть удалить функцию вычисления identification_level
3) Обновляю протокол для PM
4) Вероятно, убрать ComputeWalletTermsNew (deprecated), почистив её обработчик в PM